### PR TITLE
change autoload settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         "atoum/atoum": "master-dev"
     },
     "autoload": {
-        "psr-0": { "": "src/" }
+        "psr-0": { "M6Web\\Component\\Statsd\\": "src/" }
     }
 }


### PR DESCRIPTION
empty string in autoload configuration will result in following line inside
composer's autoload_namespaces.php:
'' => array( . '/m6web/statsd/src'),

This means autoloader will unnecessarily look for classes not provided by composer inside this package.
