### PR TITLE
Incorrect namespace usage in "Usage" doc

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,7 +1,7 @@
 # usage
 
 ```php
- $client = new Statsd\Client(
+ $client = new \M6Web\Component\Statsd\Client(
                     array(
                         'serv1' => array('address' => 'udp://200.22.143.12'),
                         'serv2' => array('port' => 8125, 'address' => 'udp://200.22.143.12')


### PR DESCRIPTION
`StatsdClient` resides under `\M6Web\Component` namespace.
Here we can either use `use \M6Web\Component\Statsd` or the fully qualified class name.
For this "usage" example I chose the FQCN.
