### PR TITLE
Clearly shows that metrics have to be explicitly sent

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -13,4 +13,6 @@ $client->count('a.graphite.node', 5);
 $client->timing('another.graphite.node', (float) $timing);
 $client->set('a.graphite.set', 12);
 $client->gauge('a.gauge.node', 8);
+
+$client->send(); // Send the metrics to the servers
 ```


### PR DESCRIPTION
By looking at the usage example, one could think metrics are immediately sent to servers when calling `Client::increment()`, `Client::count()`... which is not the case: client must be explicitly asked to send data to servers.

By adding a call to `Client::send()` I make it clear that `Client` won't send data unless asked to.