### PR TITLE
Keep socket connected between each writeDatas() call

### DIFF
--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -301,28 +301,30 @@ class Client
      * send datas to servers
      *
      * @param string $server server key
-     * @param array  $datas  array de data à env
+     * @param array  $datas  data to send
      *
      * @throws Exception
      * @return bool
      */
     public function writeDatas($server, $datas)
     {
+        static $fp = array();
+
         if (!isset($this->getServers()[$server])) {
             throw new Exception($server." undefined in the configuration");
         }
-        $s = $this->getServers()[$server];
-        $fp = fsockopen($s['address'], $s['port']);
-        if ($fp !== false) {
+
+        if (!isset($fp[$server])) {
+            $s = $this->getServers()[$server];
+            $fp[$server] = fsockopen($s['address'], $s['port']);
+        }
+
+        if ($fp[$server] !== false) {
             foreach ($datas as $value) {
                 // write packets
-                if (!@fwrite($fp, $value)) {
+                if (!@fwrite($fp[$server], $value)) {
                     return false;
                 }
-            }
-            // close conn
-            if (!fclose($fp)) {
-                return false;
             }
         } else {
             return false;


### PR DESCRIPTION
Actually if we got X data to send on statsd, the client will open and close X sockets to the statsd server.

This PR modifies this behavior to 'persist' socket between each date write.

The downsite I see is in case of long running PHP jobs, where it can not be a nice thing to let socket opened for a long time. But in a web context, it's nice.