### PR TITLE
POC : Add tags support for influxDb 0.9

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -14,5 +14,15 @@ $client->timing('another.graphite.node', (float) $timing);
 $client->set('a.graphite.set', 12);
 $client->gauge('a.gauge.node', 8);
 
+// with tags for influxDb 0.9 : add the tags array at the end of each function
+$tags = ['foo' => 'bar', 'site' => 'www', 'country' => 'fr'];
+$sampleRate = 1;
+
+$client->increment('a.influxDb.node',  $sampleRate, $tags);
+$client->count('a.influxDb.node', 5, $sampleRate, $tags);
+$client->timing('another.influxDb.node', (float) $timing, $sampleRate, $tags);
+$client->set('a.influxDb.set', 12, $sampleRate, $tags);
+$client->gauge('a.influxDb.node', 8, $sampleRate, $tags);
+
 $client->send(); // Send the metrics to the servers
 ```

--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -322,7 +322,6 @@ class Client
         $fp = fsockopen($s['address'], $s['port']);
         if ($fp !== false) {
             foreach ($datas as $value) {
-                var_dump($value);
                 // write packets
                 if (!@fwrite($fp, $value)) {
                     return false;

--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -133,14 +133,15 @@ class Client
      * @param string $value      value
      * @param float  $sampleRate sampling rate
      * @param string $unit       unit
+     * @param array  $tags       Tags key => value for influxDb
      *
      * @return Client
      */
-    protected function addToSend($stats, $value, $sampleRate, $unit)
+    protected function addToSend($stats, $value, $sampleRate, $unit, $tags)
     {
 
         $message =  new MessageEntity(
-            (string) $stats, (int) $value, (string) $unit, (float) $sampleRate
+            (string) $stats, (int) $value, (string) $unit, (float) $sampleRate, $tags
         );
 
         $queue = [
@@ -175,12 +176,13 @@ class Client
      * @param string    $stats      The metric to in log timing info for.
      * @param int       $time       The ellapsed time (ms) to log
      * @param float|int $sampleRate the rate (0-1) for sampling.
+     * @param array     $tags       Tags key => value for influxDb
      *
      * @return Client
      */
-    public function timing($stats, $time, $sampleRate = 1.0)
+    public function timing($stats, $time, $sampleRate = 1.0, $tags = [])
     {
-        $this->addToSend($stats, $time, $sampleRate, 'ms');
+        $this->addToSend($stats, $time, $sampleRate, 'ms', $tags);
 
         return $this;
     }
@@ -190,14 +192,15 @@ class Client
      *
      * @param string $stats      The metric(s) to increment.
      * @param float  $sampleRate SamplingRate
+     * @param array  $tags       Tags key => value for influxDb
      *
      * @internal param $ float|1 $sampleRate the rate (0-1) for sampling.
      *
      * @return Client
      */
-    public function increment($stats, $sampleRate = 1.0)
+    public function increment($stats, $sampleRate = 1.0, $tags = [])
     {
-        $this->count($stats, '1', $sampleRate);
+        $this->count($stats, '1', $sampleRate, $tags);
 
         return $this;
     }
@@ -208,12 +211,13 @@ class Client
      *
      * @param string    $stats      The metric(s) to decrement.
      * @param float|int $sampleRate the rate (0-1) for sampling.
+     * @param array     $tags       Tags key => value for influxDb
      *
      * @return Client
      */
-    public function decrement($stats, $sampleRate = 1)
+    public function decrement($stats, $sampleRate = 1, $tags = [])
     {
-        $this->count($stats, '-1', $sampleRate);
+        $this->count($stats, '-1', $sampleRate, $tags);
 
         return $this;
     }
@@ -224,14 +228,15 @@ class Client
      * @param string    $stats      The metric(s) to count
      * @param int       $value      The count value
      * @param float|int $sampleRate the rate (0-1) for sampling.
+     * @param array     $tags       Tags key => value for influxDb
      *
      * @access public
      *
      * @return Client
      */
-    public function count($stats, $value, $sampleRate = 1)
+    public function count($stats, $value, $sampleRate = 1, $tags = [])
     {
-        $this->addToSend($stats, $value, $sampleRate, 'c');
+        $this->addToSend($stats, $value, $sampleRate, 'c', $tags);
 
         return $this;
     }
@@ -242,13 +247,14 @@ class Client
      * @param string    $stats      The metric(s) to count
      * @param int       $value      The value
      * @param float|int $sampleRate the rate (0-1) for sampling.
+     * @param array     $tags       Tags key => value for influxDb
      *
      * @access public
      * @return Client
      */
-    public function gauge($stats, $value, $sampleRate = 1)
+    public function gauge($stats, $value, $sampleRate = 1, $tags = [])
     {
-        $this->addToSend($stats, $value, $sampleRate, 'g');
+        $this->addToSend($stats, $value, $sampleRate, 'g', $tags);
 
         return $this;
     }
@@ -259,13 +265,14 @@ class Client
      * @param string    $stats      The metric(s) to count
      * @param int       $value      The value
      * @param float|int $sampleRate the rate (0-1) for sampling.
+     * @param array     $tags       Tags key => value for influxDb
      *
      * @access public
      * @return Client
      */
-    public function set($stats, $value, $sampleRate = 1)
+    public function set($stats, $value, $sampleRate = 1, $tags = [])
     {
-        $this->addToSend($stats, $value, $sampleRate, 's');
+        $this->addToSend($stats, $value, $sampleRate, 's', $tags);
 
         return $this;
     }
@@ -315,6 +322,7 @@ class Client
         $fp = fsockopen($s['address'], $s['port']);
         if ($fp !== false) {
             foreach ($datas as $value) {
+                var_dump($value);
                 // write packets
                 if (!@fwrite($fp, $value)) {
                     return false;

--- a/src/M6Web/Component/Statsd/MessageEntity.php
+++ b/src/M6Web/Component/Statsd/MessageEntity.php
@@ -39,6 +39,7 @@ class MessageEntity
      * @param int    $value      value of the node
      * @param string $unit       units (ms for timer, c for counting ...)
      * @param float  $sampleRate sampling rate
+     * @param array  $tags       Tags key => value for influxDb
      *
      * @return MessageEntity
      */

--- a/src/M6Web/Component/Statsd/MessageEntity.php
+++ b/src/M6Web/Component/Statsd/MessageEntity.php
@@ -130,14 +130,6 @@ class MessageEntity
     }
 
     /**
-     * @return array
-     */
-    public function getTags()
-    {
-        return $this->tags;
-    }
-
-    /**
      * @return string Tags formatted for sending
      * ex: "server=5,country=fr"
      */
@@ -145,7 +137,7 @@ class MessageEntity
     {
         $tags = array_map(function($k, $v) {
             return $k.'='.$v;
-        }, array_keys($this->getTags()), $this->getTags());
+        }, array_keys($this->tags), $this->tags);
 
         return implode(',', $tags);
     }

--- a/src/M6Web/Component/Statsd/MessageEntity.php
+++ b/src/M6Web/Component/Statsd/MessageEntity.php
@@ -148,9 +148,11 @@ class MessageEntity
      */
     private function getFullNode()
     {
-        $tagsString = $this->getTagsAsString();
+        if ($this->tags) {
+            return $this->getNode().','.$this->getTagsAsString();
+        }
 
-        return $tagsString ? $this->getNode().','.$tagsString : $this->getNode();
+        return $this->getNode();
     }
 
     /**

--- a/src/M6Web/Component/Tests/Units/MessageEntity.php
+++ b/src/M6Web/Component/Tests/Units/MessageEntity.php
@@ -95,5 +95,10 @@ class MessageEntity extends atoum\test
             })
             ->isInstanceOf('\M6Web\Component\Statsd\Exception');
 
+        $this->exception(
+            function() {
+                new Statsd\MessageEntity('raoul.node', 1, 'c', 1, 'stringTag');
+            }
+        )->isInstanceOf('\M6Web\Component\Statsd\Exception');
     }
 }

--- a/src/M6Web/Component/Tests/Units/MessageEntity.php
+++ b/src/M6Web/Component/Tests/Units/MessageEntity.php
@@ -56,6 +56,14 @@ class MessageEntity extends atoum\test
                 ->string($messageEntity->getStatsdMessage())
                     ->isEqualTo('raoul.node:1|c|@0.2')
         ;
+
+        // with tags
+        $this->if($messageEntity = new Statsd\MessageEntity(
+            'raoul.node', 1, 'c', 0.2, ['foo' => 'bar']))
+            ->then()
+            ->string($messageEntity->getStatsdMessage())
+            ->isEqualTo('raoul.node,foo=bar:1|c|@0.2')
+        ;
     }
 
     public function testErrorConstructorStatsdMessage()


### PR DESCRIPTION
Node is "merged" with tags : 

*foo:1|c* into *foo,tag1=value1,tag2=value2:1|c*

Tests still passing, sending format is not modified if no tags are sent.