### PR TITLE
Add ability to set prefix to stats names

### DIFF
--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -94,7 +94,7 @@ class Client
     /**
      * set stats prefix
      *
-     * @param $prefix prefix
+     * @param string $prefix a prefix to prepend to all stats names
      */
     public function setPrefix($prefix)
     {

--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -35,6 +35,12 @@ class Client
     private $serverKeys = array();
 
     /**
+     * stats names prefix
+     * @var array
+     */
+    private $prefix = '';
+
+    /**
      * contructeur
      * @param array $servers les serveurs
      */
@@ -83,6 +89,16 @@ class Client
     protected function initQueue()
     {
         $this->toSend = new \SplQueue();
+    }
+
+    /**
+     * set stats prefix
+     *
+     * @param $prefix prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
     }
 
     /**
@@ -163,7 +179,7 @@ class Client
 
         foreach ($this->getToSend() as $metric) {
             $server = $metric['server'];
-            $sampledData[$server][] = $metric['message']->getStatsdMessage();
+            $sampledData[$server][] = $this->prefix . $metric['message']->getStatsdMessage();
 
         }
 


### PR DESCRIPTION
Usage:

```
use \M6Web\Component\Statsd;
$statsd = new Statsd\Client([...]);
$statsd->setPrefix('my.website.');
$statsd->increment('service.coucougraphite');
$statsd->send();
```

This results in updating the `my.website.service.coucougraphite`. It allows to avoid spreading the same prefix across the whole application.