### PR TITLE
Now failing silently if Statsd server is unreachable

### DIFF
--- a/src/M6Web/Component/Statsd/Client.php
+++ b/src/M6Web/Component/Statsd/Client.php
@@ -319,7 +319,7 @@ class Client
             throw new Exception($server." undefined in the configuration");
         }
         $s = $this->getServers()[$server];
-        $fp = fsockopen($s['address'], $s['port']);
+        $fp = @fsockopen($s['address'], $s['port']);
         if ($fp !== false) {
             foreach ($datas as $value) {
                 // write packets


### PR DESCRIPTION
If the specified Statsd server is unreachable, PHP throws a warning turned into an exception by Symfony:

```
ContextErrorException in Client.php line 322:
Warning: fsockopen(): php_network_getaddresses: getaddrinfo failed: Name or service not known
```

I suggest failing silently instead, as Statsd is mostly used for metrics monitoring, which should not prevent the application from doing its main job upon failure.