### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,2 +1,0 @@
-<?php
-require __DIR__ . '/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "atoum/atoum": "~2.0",
+        "atoum/atoum": "^2.8|^3.0",
         "m6web/symfony2-coding-standard": "~1.2",
         "m6web/coke": "~1.2"
     },


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.